### PR TITLE
Dependabot による依存関係の自動更新を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "05:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 3
+    commit-message:
+      prefix: "deps(workflow)"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "05:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      semver-major-days: 10
+      semver-minor-days: 5
+      semver-patch-days: 3
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(pnpm)"


### PR DESCRIPTION
## 概要

Dependabot の設定ファイル（`.github/dependabot.yml`）を追加し、GitHub Actions と npm（pnpm）の依存関係を週次で自動更新するようにしました。

## 変更内容

- `github-actions` エコシステムを対象に、週次（土曜 05:00 JST）で更新 PR を作成
  - `cooldown.default-days: 3` により、リリース直後のバージョンは 3 日待ってから取り込む
  - コミットメッセージ prefix は `deps(workflow)`
- `npm` エコシステムを対象に、同じスケジュールで更新 PR を作成
  - `cooldown` を semver レベル別に設定（major: 10日 / minor: 5日 / patch: 3日）
  - 同時オープン PR 数の上限は 10
  - コミットメッセージ prefix は `deps(pnpm)`

`cooldown` の設定は、`pnpm-workspace.yaml` で既に指定している `minimumReleaseAge: 4320`（3日）と方針を揃える意図です。サプライチェーン攻撃で公開直後に取り下げられるパッケージを避けるための待機期間になります。

## 動作確認

- `yamllint -c .yamllint .github/dependabot.yml` → エラーなし（CI の yamllint ジョブと同じ設定で確認）

Dependabot 自体の実挙動（PR が実際に作成されるか）は、main へマージ後に GitHub 側で設定が読み込まれるため未確認です。マージ後に Insights > Dependency graph > Dependabot で設定の読み込み状況を確認する想定です。

## 影響範囲・注意点

- CI は `pull_request` トリガーのため、Dependabot が作成する PR でも CI が走ります。`GITHUB_TOKEN` の権限は Dependabot PR では read-only に制限されますが、現行 CI は typecheck / build / lint のみなので影響はない見込みです
- npm 側は最大 10 本の PR が同時に開く可能性があります。運用してみて多すぎる場合は `open-pull-requests-limit` の引き下げをご検討ください
- `cooldown` は Dependabot の比較的新しいオプションです。GitHub 側の仕様変更があった場合は追随が必要になる可能性があります