### PR TITLE
SHA ピン止め action のバージョンコメントを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
         with:
           version: 11.17.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: '24.18.0'
           cache: pnpm
@@ -31,18 +31,18 @@ jobs:
         run: pnpm run build
 
       - name: Markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe  # v24.1.0
+        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe
         with:
           globs: |
             **/*.md
             !node_modules/**
 
       - name: Actionlint
-        uses: reviewdog/action-actionlint@50842263c20a7c46bd0065b9e624d3c569db061e  # v1.73.0
+        uses: reviewdog/action-actionlint@50842263c20a7c46bd0065b9e624d3c569db061e
         with:
           fail_level: error
 
       - name: Yamllint
-        uses: reviewdog/action-yamllint@e02a49fdf53f51ddd8dfa89b09aa975043aeba38  # v1.23.0
+        uses: reviewdog/action-yamllint@e02a49fdf53f51ddd8dfa89b09aa975043aeba38
         with:
           fail_level: error


### PR DESCRIPTION
## 概要

`.github/workflows/ci.yml` で SHA ピン止めしている各 action の後ろに付けていた `# vX.Y.Z` 形式のバージョンコメントを削除しました。

## 変更内容

以下 6 箇所の末尾コメントを削除しています（SHA 自体は変更していません）。

- `actions/checkout`（`# v7.0.1`）
- `pnpm/action-setup`（`# v6.0.9`）
- `actions/setup-node`（`# v7.0.0`）
- `DavidAnson/markdownlint-cli2-action`（`# v24.1.0`）
- `reviewdog/action-actionlint`（`# v1.73.0`）
- `reviewdog/action-yamllint`（`# v1.23.0`）

削除の理由は、Dependabot による更新では SHA のみが書き換わり、コメント側のバージョン表記が古いまま残ってしまうためです。実例として PR #7（`pnpm/action-setup` の更新）では SHA が `0083308...` から `0ebf471...` に変わった一方、コメントは `# v6.0.9` のまま残っており、実際にピンしているバージョンと表記が一致しない状態になっていました。誤った情報が残るより、SHA を単一の情報源にする方が安全という判断です。

## 動作確認

ローカルでの lint 実行は未実施です（yamllint / actionlint が未インストールのため）。CI の markdownlint / actionlint / yamllint ジョブでの確認を想定しています。

コメントのみの削除であり、`uses:` の参照先 SHA は変更していないため、CI の実行内容そのものには影響しない見込みです。

## 影響範囲・注意点

- コメントがなくなるため、各 SHA がどのバージョンに対応するかはコード上から読み取れなくなります。確認が必要な場合は各 action のリポジトリでタグを引く形になります
- この点をトレードオフとして許容できない場合は、代替案として (a) Dependabot の設定でコメントも追随させる方法の検討、または (b) 元の形に戻す、が考えられます。方針が異なる場合はお知らせください